### PR TITLE
Optimisations, Bugfixes and Quality-of-Life changes

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ message: >-
 type: software
 authors:
   - given-names: Axel
-    email: sandstedt225@gmail.com
+    email: axel.sandstedt97@protonmail.com
     family-names: Sandstedt
   - given-names: Johannes
     email: johannes.graner@gmail.com

--- a/src/main/scala/DensityHistogram.scala
+++ b/src/main/scala/DensityHistogram.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2022 Johannes Graner
+ * Copyright 2022 Johannes Graner, 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/Histogram.scala
+++ b/src/main/scala/Histogram.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2017 Tilo Wiklund
+ * Copyright 2017 Tilo Wiklund, 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/LeafMap.scala
+++ b/src/main/scala/LeafMap.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner
+ * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner, 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/MergeEstimator.scala
+++ b/src/main/scala/MergeEstimator.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2022 Johannes Graner
+ * Copyright 2022 Johannes Graner, 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/MergeEstimator.scala
+++ b/src/main/scala/MergeEstimator.scala
@@ -82,6 +82,23 @@ object MergeEstimatorFunctions {
     points.mapPartitions(iter => tree.quickDescend(iter, depth)).map(n => (n,1L)).reduceByKey((v1, v2) => v1 + v2)
   }
 
+  /**
+   * quickToLabeledNoReduce - Quick labeling function of datapoints without reduceByKey operation (Unecessary for validation data).
+   * 
+   * @param tree - Root Regular Paving 
+   * @param depth - The depth to split down to and determine the label
+   * @param points - The points to label and count
+   * @return A RDD containing cell NodeLabels for cells with non-zero counts. Every NodeLabel occurs only once
+   *         with the count set as the number of points found within the cell.
+   */
+  def quickToLabeledNoReduce(tree: WidestSplitTree, depth: Int, points: RDD[MLVector]): RDD[(NodeLabel, Count)] = {
+    val spark = getSpark
+    import spark.implicits._
+
+    require(depth > 0)
+    points.mapPartitions(iter => tree.quickDescend(iter, depth)).map(n => (n,1L))
+  }
+
   def getTree[A](tree: SpatialTree)(f: SpatialTree => A) = f(tree)
 
   @deprecated("Use subtree partitioning based strategy mergeLeavesRDD or mergeLeavesHistogram")

--- a/src/main/scala/MinimumDistanceEstimation.scala
+++ b/src/main/scala/MinimumDistanceEstimation.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2022 Johannes Graner
+ * Copyright 2022 Johannes Graner, 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/NodeLabel.scala
+++ b/src/main/scala/NodeLabel.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner
+ * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner, 2023 Axel Sandstedt 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/Rectangle.scala
+++ b/src/main/scala/Rectangle.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2017 Tilo Wiklund
+ * Copyright 2017 Tilo Wiklund, 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/SpatialTree.scala
+++ b/src/main/scala/SpatialTree.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner
+ * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner, 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/SubtreePartitioner.scala
+++ b/src/main/scala/SubtreePartitioner.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner
+ * Copyright 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/SubtreePartitioner.scala
+++ b/src/main/scala/SubtreePartitioner.scala
@@ -114,7 +114,8 @@ class SubtreePartitioner(partitions : Int, rdd : RDD[(NodeLabel, Count)], val sa
           val weight = (1.0 / fraction).toFloat
           candidates ++= reSampled.map(x => (x, weight))
         }
-        val weightLimit : Float = candidates.length.toFloat / partitions
+        //val weightLimit : Float = candidates.length.toFloat / partitions
+        val weightLimit : Float = candidates.map(_._2).reduce(_+_) / partitions
         val maxSubtrees = maximalWeightSubtreeGeneration(candidates.sorted.toVector, weightLimit)
         maxSubtrees
       }

--- a/src/main/scala/Truncation.scala
+++ b/src/main/scala/Truncation.scala
@@ -1,5 +1,5 @@
 /**************************************************************************
- * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner
+ * Copyright 2017 Tilo Wiklund, 2022 Johannes Graner, 2023 Axel Sandstedt
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/MDETests.scala
+++ b/src/test/scala/MDETests.scala
@@ -387,7 +387,7 @@ class MDETests extends FlatSpec with Matchers with BeforeAndAfterAll {
 
     val k = kInMDE
     var result : (Histogram, Histogram, RDD[(NodeLabel,Count)]) =
-      mdeStep(merged, countedTest.mapPartitions(_.toArray.sortBy(t => t._1)(leftRightOrd).toIterator), trainSize/2, k, stopSize, verbose)
+      mdeStep(merged, countedTest.mapPartitions(_.toArray.sortBy(t => t._1)(leftRightOrd).toIterator), trainSize/2, k, stopSize, 4, verbose)
     var best = result._1
     var largest = result._2
     var mergedValidationData = result._3
@@ -398,7 +398,7 @@ class MDETests extends FlatSpec with Matchers with BeforeAndAfterAll {
     while (sizeDiff > k/2) {
       if (verbose) println(s"----- Current size difference: $sizeDiff -----")
       stopSize = Some(largest.counts.leaves.length - 2 * sizeDiff)
-      result = mdeStep(largest, mergedValidationData, trainSize/2, k, stopSize, verbose)
+      result = mdeStep(largest, mergedValidationData, trainSize/2, k, stopSize, 4, verbose)
       correct = getValHist(largest, mergedValidationData, k, stopSize)
       best = result._1
       largest = result._2
@@ -410,7 +410,7 @@ class MDETests extends FlatSpec with Matchers with BeforeAndAfterAll {
     if (sizeDiff > 1) {
       if (verbose) println(s"----- Final step with size difference $sizeDiff -----")
       stopSize = Some(largest.counts.leaves.length - 2 * sizeDiff)
-      result = mdeStep(largest, mergedValidationData, trainSize/2, sizeDiff * 2 + 1, stopSize, verbose)
+      result = mdeStep(largest, mergedValidationData, trainSize/2, sizeDiff * 2 + 1, stopSize, 4, verbose)
       correct = getValHist(largest, mergedValidationData, sizeDiff * 2 + 1, stopSize)
       best = result._1
       largest = result._2
@@ -442,7 +442,7 @@ class MDETests extends FlatSpec with Matchers with BeforeAndAfterAll {
         (NodeLabel(24), 5),
       ), 4)
     val validationCount1 = 45
-    var result1 : (Histogram, Histogram, RDD[(NodeLabel,Count)]) = mdeStep(hist, validationData1.mapPartitions(_.toArray.sortBy(t => t._1)(leftRightOrd).toIterator), validationCount1, k, stopSize, verbose)
+    var result1 : (Histogram, Histogram, RDD[(NodeLabel,Count)]) = mdeStep(hist, validationData1.mapPartitions(_.toArray.sortBy(t => t._1)(leftRightOrd).toIterator), validationCount1, k, stopSize, 4, verbose)
     var mergedValidationData1 = result1._3.reduceByKey(_+_).collect.sortBy(_._1)
     assert(mergedValidationData1(0)._1 == NodeLabel(16) && mergedValidationData1(0)._2 == 10)
     assert(mergedValidationData1(1)._1 == NodeLabel(17) && mergedValidationData1(1)._2 == 5)
@@ -469,7 +469,7 @@ class MDETests extends FlatSpec with Matchers with BeforeAndAfterAll {
         (NodeLabel(63), 10),
       ), 8)
     val validationCount2 = 105
-    var result2 : (Histogram, Histogram, RDD[(NodeLabel,Count)]) = mdeStep(hist, validationData2.mapPartitions(_.toArray.sortBy(t => t._1)(leftRightOrd).toIterator), validationCount2, k, stopSize, verbose)
+    var result2 : (Histogram, Histogram, RDD[(NodeLabel,Count)]) = mdeStep(hist, validationData2.mapPartitions(_.toArray.sortBy(t => t._1)(leftRightOrd).toIterator), validationCount2, k, stopSize, 4, verbose)
     var mergedValidationData2 = result2._3.reduceByKey(_+_).collect.sortBy(_._1)
     assert(mergedValidationData2(0)._1 == NodeLabel(20) && mergedValidationData2(0)._2 == 5)
     assert(mergedValidationData2(1)._1 == NodeLabel(24) && mergedValidationData2(1)._2 == 5)
@@ -493,7 +493,7 @@ class MDETests extends FlatSpec with Matchers with BeforeAndAfterAll {
         (NodeLabel(24), 5),
       ), 2)
     val validationCount3  = 85
-    var result3 : (Histogram, Histogram, RDD[(NodeLabel,Count)]) = mdeStep(hist, validationData3.mapPartitions(_.toArray.sortBy(t => t._1)(leftRightOrd).toIterator), validationCount3, k, stopSize, verbose)
+    var result3 : (Histogram, Histogram, RDD[(NodeLabel,Count)]) = mdeStep(hist, validationData3.mapPartitions(_.toArray.sortBy(t => t._1)(leftRightOrd).toIterator), validationCount3, k, stopSize, 4, verbose)
     var mergedValidationData3 = result3._3.reduceByKey(_+_).collect.sortBy(_._1)
     assert(mergedValidationData3(0)._1 == NodeLabel(20) && mergedValidationData3(0)._2 == 5)
     assert(mergedValidationData3(2)._1 == NodeLabel(22) && mergedValidationData3(2)._2 == 25)

--- a/src/test/scala/ScalaDensityTest.scala
+++ b/src/test/scala/ScalaDensityTest.scala
@@ -134,6 +134,7 @@ class DensityTests extends FlatSpec with Matchers with BeforeAndAfterAll {
       countedValidation, 
       trainSize/2,
       kInMDE, 
+      4,
       false 
     )).normalize
 
@@ -1036,6 +1037,7 @@ class DensityTests extends FlatSpec with Matchers with BeforeAndAfterAll {
       countedTest, 
       trainSize/2,
       kInMDE, 
+      4,
       true 
     )).normalize
 


### PR DESCRIPTION
Bugfixes:
- Weight limit of subtrees in SubtreePartitioner is correctly calculated now

Optimisations:
- ReduceByKey step added to first iteration in getMDE, shuffle cost very little at that point and removes leaf duplication within partitions
- New methods for labelling validation data which has removed the reduceByKey call in the training data labelling counterpart
- Broadcasting CRP instead of serialising it for every individual task in mdeStep

Quality of life changes:
Added a getCountLimit method. The user should use this method to generate a countLimit, since it returns a limit at least as large as the maximum count of the input leaves. 
